### PR TITLE
Add example tech writer portfolio docs

### DIFF
--- a/tech-writer-portfolio/01-dev-docs/cli-tool-documentation.md
+++ b/tech-writer-portfolio/01-dev-docs/cli-tool-documentation.md
@@ -1,0 +1,24 @@
+# CLI Tool Documentation
+
+## Overview
+This document explains how to use the command-line interface that accompanies the product. It summarizes available options, provides examples, and offers troubleshooting tips for common errors encountered by new users.
+
+## Audience
+The guide is for developers and system administrators who prefer working in a terminal or need to automate tasks through scripts. Basic knowledge of shell syntax and environment variables is assumed.
+
+## Objective
+Help users become productive with the CLI by documenting essential commands and showing how they fit into development or deployment workflows. The instructions focus on cross-platform compatibility and standard conventions.
+
+## Usage Scenarios
+Reference this document when automating build processes, performing administrative tasks, or integrating the CLI into continuous integration pipelines. It is also helpful during local development when scripting repetitive tasks.
+
+## Best Practices
+Use clear naming for scripts and avoid embedding sensitive information in command lines. Favor environment variables or configuration files for secrets. Test scripts on a non-production environment before running them in automation pipelines.
+
+## Action Steps
+1. Install the CLI tool using the package manager for your platform.
+2. Run `command --help` to list global options and available subcommands.
+3. Configure authentication and environment variables as needed.
+4. Execute basic commands to create, read, update, and delete resources.
+5. Integrate the CLI with your build scripts or automated workflows.
+6. Review the troubleshooting section if you encounter permission errors or other issues.

--- a/tech-writer-portfolio/01-dev-docs/getting-started-guide.md
+++ b/tech-writer-portfolio/01-dev-docs/getting-started-guide.md
@@ -1,0 +1,24 @@
+# Getting Started Guide
+
+## Overview
+This guide introduces new users to the core features of the product. It covers installation, basic configuration, and a short tour of the primary tools that help teams become productive quickly. The focus is on clarity and simplicity so first-time readers can follow along without prior knowledge.
+
+## Audience
+This document is intended for developers who are setting up the environment for the first time. It assumes basic familiarity with the command line and source control. Readers should come away confident in their ability to install the software and execute common commands.
+
+## Objective
+Provide step-by-step instructions that enable new team members to set up the tool in under thirty minutes. The guide also explains how to verify the installation and where to find additional resources.
+
+## Usage Scenarios
+Use this guide when onboarding developers or when setting up a fresh workstation. It can also serve as a reference for troubleshooting initial configuration problems.
+
+## Best Practices
+Keep configuration files under version control to ensure reproducibility. Document any environment variables so that team members can replicate the setup. Encourage developers to read through the entire guide before running commands.
+
+## Action Steps
+1. Download the installer from the official site.
+2. Run the installation script using administrator privileges.
+3. Initialize the configuration with default settings.
+4. Clone the project repository and build the sample project.
+5. Verify that all unit tests pass.
+6. Consult the troubleshooting section if any errors occur.

--- a/tech-writer-portfolio/01-dev-docs/rest-api-reference.md
+++ b/tech-writer-portfolio/01-dev-docs/rest-api-reference.md
@@ -1,0 +1,24 @@
+# REST API Reference
+
+## Overview
+This reference describes the available endpoints, request parameters, and response formats for integrating with the service. Each section lists HTTP verbs, resource paths, and example payloads so that developers can quickly understand how to interact with the API securely and efficiently.
+
+## Audience
+Developers building integrations or custom tooling that rely on the service. Familiarity with HTTP and JSON is assumed. Prior experience with authentication methods such as OAuth is helpful but not required.
+
+## Objective
+Provide a complete catalog of endpoints and configuration options so that developers can implement features without guesswork. The reference includes details about rate limits and error codes.
+
+## Usage Scenarios
+Use this documentation when implementing new endpoints or troubleshooting unexpected responses. It can also serve as a quick reference for building automation scripts.
+
+## Best Practices
+Follow the service guidelines for pagination and caching. Test calls in a staging environment before hitting production servers. Handle error codes gracefully and use retries where appropriate.
+
+## Action Steps
+1. Review authentication requirements and obtain necessary tokens.
+2. Choose the correct base URL for your environment.
+3. Construct the request with required headers and parameters.
+4. Validate responses against expected schemas.
+5. Monitor rate limits and adjust request frequency if needed.
+6. Consult the troubleshooting guide for common error scenarios.

--- a/tech-writer-portfolio/02-ai-and-data-docs/ai-handbook-summary.md
+++ b/tech-writer-portfolio/02-ai-and-data-docs/ai-handbook-summary.md
@@ -1,0 +1,24 @@
+# AI Handbook Summary
+
+## Overview
+This summary distills key points from the organization's AI handbook. It covers ethical considerations, data privacy requirements, and guidelines for responsible machine learning practices. Readers will gain a broad understanding of how AI projects are evaluated and monitored within the company.
+
+## Audience
+Project managers, developers, and legal teams who oversee or implement AI initiatives. The document helps ensure cross-functional alignment on compliance and governance standards.
+
+## Objective
+Highlight the most important policies in a concise format. It aims to make it easy for stakeholders to reference best practices when planning or reviewing AI-driven features.
+
+## Usage Scenarios
+Refer to this summary when conducting risk assessments or preparing documentation for regulatory approval. It can also serve as onboarding material for new employees joining the AI team.
+
+## Best Practices
+Adhere to local and international privacy laws when collecting data. Document how algorithms are trained, and provide clear channels for user feedback. Regularly audit models to detect drift or bias.
+
+## Action Steps
+1. Review the full AI handbook to understand the broader policy landscape.
+2. Integrate privacy checks into your development workflow.
+3. Maintain transparent records of training datasets and model performance.
+4. Engage with legal and compliance teams early in the project lifecycle.
+5. Encourage open communication about ethical concerns.
+6. Schedule periodic reviews to update guidelines based on new regulations.

--- a/tech-writer-portfolio/02-ai-and-data-docs/ml-pipeline-explainer.md
+++ b/tech-writer-portfolio/02-ai-and-data-docs/ml-pipeline-explainer.md
@@ -1,0 +1,24 @@
+# ML Pipeline Explainer
+
+## Overview
+This document outlines the stages of a typical machine learning pipeline, from data collection to model deployment. It breaks down each phase—such as preprocessing, training, evaluation, and monitoring—and highlights best practices to maintain reproducibility and accountability.
+
+## Audience
+Data engineers and machine learning practitioners who want to understand how different components interact. The explainer is also useful for technical stakeholders seeking a high-level overview of the process.
+
+## Objective
+Clarify the end-to-end workflow of machine learning projects. By detailing each step, the document helps teams align on responsibilities and identify where automation can reduce manual effort.
+
+## Usage Scenarios
+Use this explainer when designing new pipelines or reviewing existing ones. It can help pinpoint bottlenecks or areas where additional tooling might increase efficiency.
+
+## Best Practices
+Ensure that data preprocessing steps are versioned and logged. Employ continuous integration to run unit tests on pipeline components. Establish metrics to track model performance after deployment.
+
+## Action Steps
+1. Outline the data sources and collection strategy.
+2. Document preprocessing operations and transformation logic.
+3. Describe model training methods, including hyperparameter tuning.
+4. Specify evaluation metrics and validation procedures.
+5. Detail the deployment process and mechanisms for rollback.
+6. Plan for ongoing monitoring and periodic retraining based on new data.

--- a/tech-writer-portfolio/02-ai-and-data-docs/prompt-framework-guide.md
+++ b/tech-writer-portfolio/02-ai-and-data-docs/prompt-framework-guide.md
@@ -1,0 +1,24 @@
+# Prompt Framework Guide
+
+## Overview
+This guide introduces best practices for creating effective prompts when working with large language models. It explains key concepts behind prompt engineering, such as role specification, context inclusion, and iterative refinement. By following these guidelines, teams can improve the relevance and accuracy of AI-generated responses.
+
+## Audience
+Data scientists, machine learning engineers, and technical writers who need to design prompts for AI-driven applications. Some familiarity with natural language processing concepts is helpful but not required.
+
+## Objective
+Provide actionable guidance on structuring prompts that yield consistent results. The document covers common pitfalls and illustrates how to evaluate output for quality and bias.
+
+## Usage Scenarios
+Use this guide when developing chatbots, content generation tools, or any application that relies on large language models. The principles also apply to automated testing frameworks where prompt consistency is critical.
+
+## Best Practices
+Define the desired role or persona for the AI clearly in the prompt. Include relevant context without overwhelming the model. Experiment with format variations and temperature settings to achieve predictable behavior.
+
+## Action Steps
+1. Identify the goal of the conversation or text generation task.
+2. Craft a concise prompt that sets expectations for style and tone.
+3. Provide necessary background information in a structured manner.
+4. Test different wording to see how it affects the response.
+5. Evaluate results for clarity, completeness, and absence of bias.
+6. Document successful prompt formats for future reference.

--- a/tech-writer-portfolio/03-enterprise-change-comms/hybrid-rollout-guide.md
+++ b/tech-writer-portfolio/03-enterprise-change-comms/hybrid-rollout-guide.md
@@ -1,0 +1,24 @@
+# Hybrid Rollout Guide
+
+## Overview
+This guide provides an approach for rolling out new software or services using a hybrid model, where a subset of users adopts the changes before the full organization does. The strategy helps reduce risk and gather feedback from early adopters.
+
+## Audience
+Project managers, IT administrators, and support teams responsible for deploying new solutions across multiple departments or regions.
+
+## Objective
+Describe how to plan and execute a phased deployment with minimal disruption. The guide explains how to select pilot groups, set success criteria, and scale gradually based on user feedback.
+
+## Usage Scenarios
+Use this approach when launching major upgrades or when migrating to a new platform that requires careful monitoring. A hybrid rollout is also useful for training purposes, allowing teams to document best practices while adoption expands.
+
+## Best Practices
+Communicate clearly with pilot groups so they know how to report issues. Maintain parallel systems during the trial phase to allow rollback if critical problems arise. Measure key metrics to gauge adoption and user satisfaction.
+
+## Action Steps
+1. Identify candidate teams or regions for the initial rollout.
+2. Provide training materials and support channels for the pilot users.
+3. Collect feedback and evaluate success metrics.
+4. Address issues promptly and update documentation.
+5. Expand the rollout to additional groups once initial targets confirm stability.
+6. Conduct a final review and announce full deployment.

--- a/tech-writer-portfolio/03-enterprise-change-comms/jira-cloud-migration.md
+++ b/tech-writer-portfolio/03-enterprise-change-comms/jira-cloud-migration.md
@@ -1,0 +1,24 @@
+# Jira Cloud Migration
+
+## Overview
+This guide walks through the process of migrating from Jira Server to Jira Cloud. It covers data export, migration tools, and post-migration validation steps to ensure a smooth transition with minimal downtime.
+
+## Audience
+IT administrators and project managers responsible for migrating existing Jira projects to the cloud platform. Familiarity with Jira administration is assumed.
+
+## Objective
+Provide a reliable plan that reduces risk during migration. The guide explains how to back up data, configure the migration assistant, and verify that user permissions and workflows are preserved.
+
+## Usage Scenarios
+Use this document when planning a large-scale migration or when testing the process in a staging environment. The steps can also help teams evaluate whether a phased or full migration is best suited to their situation.
+
+## Best Practices
+Perform a trial run in a non-production environment to identify potential issues. Communicate clearly with end users about expected downtime. Monitor the migration progress and resolve errors promptly.
+
+## Action Steps
+1. Review system requirements and upgrade Jira Server if necessary.
+2. Back up all projects and attachments.
+3. Run the Jira Cloud Migration Assistant to export data.
+4. Import the data into the target Cloud instance.
+5. Verify user accounts, permissions, and workflows.
+6. Schedule a final cutover and inform stakeholders.

--- a/tech-writer-portfolio/03-enterprise-change-comms/org-wide-policy-change.md
+++ b/tech-writer-portfolio/03-enterprise-change-comms/org-wide-policy-change.md
@@ -1,0 +1,24 @@
+# Organization-Wide Policy Change
+
+## Overview
+This document outlines the communication strategy and rollout plan for implementing significant policy changes across the organization. It provides guidance on stakeholder engagement, timing, and feedback channels.
+
+## Audience
+Change management teams, HR professionals, and department leaders who must coordinate messaging about new policies to employees, contractors, and third parties.
+
+## Objective
+Ensure that policy updates are understood and adopted consistently. The document explains how to craft clear announcements, address frequently asked questions, and monitor the impact of the change.
+
+## Usage Scenarios
+Use this guide when implementing new compliance requirements or adjusting company-wide benefits. The steps can also apply to updates in security or privacy policies.
+
+## Best Practices
+Provide ample notice before changes take effect. Offer training sessions or informational webinars where employees can ask questions. Track metrics such as policy acknowledgments and training completion rates.
+
+## Action Steps
+1. Identify key stakeholders and designate a communications lead.
+2. Draft a concise summary of the policy changes and their rationale.
+3. Publish the announcement across internal channels.
+4. Schedule Q&A sessions to address concerns.
+5. Update relevant documentation and intranet resources.
+6. Gather feedback and adjust the rollout plan as necessary.

--- a/tech-writer-portfolio/04-strategy-and-governance/content-governance-model.md
+++ b/tech-writer-portfolio/04-strategy-and-governance/content-governance-model.md
@@ -1,0 +1,24 @@
+# Content Governance Model
+
+## Overview
+This document describes a framework for managing content across multiple teams and platforms. It outlines roles, workflows, and approval processes to maintain consistency and quality in all published materials.
+
+## Audience
+Content strategists, technical writers, and project managers responsible for coordinating documentation efforts across the organization.
+
+## Objective
+Provide a clear governance structure that supports collaboration while ensuring adherence to style guidelines and brand standards. The model aims to streamline review cycles and reduce duplicated effort.
+
+## Usage Scenarios
+Use this model when scaling documentation efforts or when establishing content standards across different teams. It is particularly valuable for organizations that maintain multiple repositories or websites.
+
+## Best Practices
+Define ownership for each stage of the content lifecycle. Use automated checks for style and formatting. Maintain a centralized style guide and provide templates for common document types.
+
+## Action Steps
+1. Establish a content governance board with representatives from key teams.
+2. Document the review and approval workflow.
+3. Create templates and style guides accessible to all contributors.
+4. Implement automated linting and build processes.
+5. Schedule regular audits to ensure compliance.
+6. Encourage feedback loops to improve the process over time.

--- a/tech-writer-portfolio/04-strategy-and-governance/editorial-workflow.md
+++ b/tech-writer-portfolio/04-strategy-and-governance/editorial-workflow.md
@@ -1,0 +1,24 @@
+# Editorial Workflow
+
+## Overview
+This document defines the editorial workflow for producing, reviewing, and publishing content. The goal is to ensure accuracy, clarity, and adherence to style guidelines throughout the content lifecycle.
+
+## Audience
+Editors, content managers, and subject matter experts who collaborate on publishing technical documentation or marketing materials.
+
+## Objective
+Establish a repeatable process for content creation that includes peer reviews, quality checks, and sign-off procedures. The workflow aims to minimize errors and streamline collaboration between writers and reviewers.
+
+## Usage Scenarios
+Use this workflow for new articles, product release notes, and updates to existing documents. It is particularly useful in organizations with multiple contributors working on shared repositories.
+
+## Best Practices
+Maintain version control for all drafts. Schedule regular checkpoints to evaluate progress. Encourage open communication among contributors to resolve issues promptly.
+
+## Action Steps
+1. Submit a content proposal outlining the purpose and target audience.
+2. Assign authors, editors, and reviewers with clear deadlines.
+3. Draft the content using approved templates and style guides.
+4. Conduct peer reviews and incorporate feedback.
+5. Finalize the document after editorial sign-off.
+6. Publish the content and monitor metrics for engagement and accuracy.

--- a/tech-writer-portfolio/04-strategy-and-governance/modular-docs-architecture.md
+++ b/tech-writer-portfolio/04-strategy-and-governance/modular-docs-architecture.md
@@ -1,0 +1,24 @@
+# Modular Documentation Architecture
+
+## Overview
+This guide introduces a modular approach to building documentation sets. By breaking content into reusable components, teams can maintain consistency, reduce duplication, and scale their documentation efforts efficiently.
+
+## Audience
+Technical writers, developers, and architects who maintain large documentation repositories. The approach is useful for teams that need to deliver updates across multiple products or services.
+
+## Objective
+Explain how to design and implement a modular documentation structure. The document covers topics such as component libraries, versioning, and automated assembly of deliverables.
+
+## Usage Scenarios
+Use this architecture when your documentation spans several products with shared concepts or when you require translations into multiple languages. Modular content is also beneficial for API documentation and code samples.
+
+## Best Practices
+Create a central repository for shared components. Use metadata to manage dependencies between modules. Automate builds so that updates propagate across all deliverables consistently.
+
+## Action Steps
+1. Identify common topics that can be reused across documentation sets.
+2. Develop a taxonomy and file-naming convention for components.
+3. Implement version control workflows that align with software releases.
+4. Use continuous integration pipelines to generate composite documents.
+5. Review the structure periodically to ensure it meets evolving needs.
+6. Provide contributor guidelines to encourage consistent style and structure.

--- a/tech-writer-portfolio/05-templates-and-toolkits/ai-onboarding-template.md
+++ b/tech-writer-portfolio/05-templates-and-toolkits/ai-onboarding-template.md
@@ -1,0 +1,24 @@
+# AI Onboarding Template
+
+## Overview
+This template is designed to help new team members understand how AI is used within the organization. It outlines key resources, introductory training modules, and points of contact for further assistance.
+
+## Audience
+New hires, contractors, or interns who need a primer on the company's AI initiatives, tools, and best practices.
+
+## Objective
+Provide a clear path for onboarding so new team members can quickly ramp up and contribute to AI-related projects. The template ensures that essential background information is conveyed consistently.
+
+## Usage Scenarios
+Use this template when onboarding new data scientists, machine learning engineers, or any employees who interact with AI systems. It can also be adapted for partner organizations or consultants.
+
+## Best Practices
+Include links to internal documentation, repositories, and training sessions. Encourage new team members to complete hands-on tutorials and review code examples. Offer mentoring opportunities when possible.
+
+## Action Steps
+1. Introduce the AI program's goals and organizational structure.
+2. Provide accounts for required tools and data sources.
+3. Outline initial training modules with estimated completion times.
+4. Assign a mentor or point of contact for questions.
+5. Schedule follow-up meetings to review progress.
+6. Gather feedback to improve the onboarding process over time.

--- a/tech-writer-portfolio/05-templates-and-toolkits/release-notes-template.md
+++ b/tech-writer-portfolio/05-templates-and-toolkits/release-notes-template.md
@@ -1,0 +1,24 @@
+# Release Notes Template
+
+## Overview
+This template provides a standardized format for announcing new releases. It includes sections for highlights, bug fixes, and known issues, ensuring that end users and stakeholders receive consistent information about updates.
+
+## Audience
+Product managers, release engineers, and technical writers responsible for drafting and distributing release notes to customers or internal teams.
+
+## Objective
+Offer a clear outline that captures key changes in each release. Using this template ensures that updates are communicated effectively and that all relevant details are presented in a concise manner.
+
+## Usage Scenarios
+Use this template whenever a new version of your software is released. It can be adapted for regular maintenance updates or major feature rollouts.
+
+## Best Practices
+Keep descriptions brief and use bullet points for readability. Provide links to documentation or support resources for more information. If possible, categorize changes by user impact.
+
+## Action Steps
+1. Summarize the main features or improvements in the release.
+2. List resolved issues with reference numbers if applicable.
+3. Document any known issues or workarounds.
+4. Provide instructions for upgrading or installation.
+5. Include contact information for support questions.
+6. Review for accuracy and clarity before distribution.

--- a/tech-writer-portfolio/05-templates-and-toolkits/retrospective-template.md
+++ b/tech-writer-portfolio/05-templates-and-toolkits/retrospective-template.md
@@ -1,0 +1,24 @@
+# Retrospective Template
+
+## Overview
+This template facilitates structured reflection after a project or sprint. It guides teams through discussing what went well, what could be improved, and how to apply lessons learned to future work.
+
+## Audience
+Agile teams, project managers, and facilitators who conduct regular retrospectives to drive continuous improvement.
+
+## Objective
+Provide a consistent format that encourages honest feedback and actionable insights. By following this template, teams can identify patterns and implement changes that enhance productivity and collaboration.
+
+## Usage Scenarios
+Use this template at the end of each development sprint or after completing a major milestone. It can also be adapted for post-mortem reviews in operations.
+
+## Best Practices
+Create a safe environment where participants feel comfortable sharing their thoughts. Use timeboxes to keep discussions focused, and document agreed-upon action items.
+
+## Action Steps
+1. Schedule the retrospective shortly after the project phase ends.
+2. Invite all relevant stakeholders and provide an agenda in advance.
+3. Review accomplishments and challenges from the past period.
+4. Brainstorm improvements and prioritize the top items.
+5. Assign owners for each action item.
+6. Follow up on progress in the next retrospective session.

--- a/tech-writer-portfolio/06-ci-cd-examples/pdf-conversion.md
+++ b/tech-writer-portfolio/06-ci-cd-examples/pdf-conversion.md
@@ -1,0 +1,24 @@
+# PDF Conversion Pipeline
+
+## Overview
+This document describes an example continuous integration pipeline that converts Markdown documentation into PDF files. It highlights the necessary dependencies, configuration steps, and recommended tools for achieving consistent output during automated builds.
+
+## Audience
+DevOps engineers and technical writers who maintain documentation in source control and want to publish PDF versions as part of a CI/CD workflow.
+
+## Objective
+Provide a step-by-step guide for setting up a PDF conversion process. The pipeline ensures that documentation is generated automatically whenever changes are merged, reducing manual effort and ensuring up-to-date PDFs.
+
+## Usage Scenarios
+Use this pipeline when distributing offline versions of docs or when integrating with release deliverables. It is valuable for teams that require formal or secure documentation packages for customers.
+
+## Best Practices
+Cache dependencies in the CI environment to speed up builds. Validate Markdown syntax before conversion to catch errors early. Store generated PDFs as build artifacts for easy retrieval.
+
+## Action Steps
+1. Choose a conversion tool such as Pandoc or an equivalent.
+2. Set up the CI environment with required packages and fonts.
+3. Add a build step that runs the conversion script for each Markdown file.
+4. Save output PDFs as artifacts or upload them to cloud storage.
+5. Monitor build logs for warnings or errors.
+6. Schedule periodic reviews to confirm the PDFs meet quality standards.

--- a/tech-writer-portfolio/README.md
+++ b/tech-writer-portfolio/README.md
@@ -1,0 +1,4 @@
+# Tech Writer Portfolio
+
+This repository contains a collection of documentation assets organized by topic. Each section showcases approaches to technical writing across different domains, including development, artificial intelligence, enterprise communications, governance, and operations. The documents follow a consistent structure so readers can easily locate background information, intended audiences, key objectives, usage scenarios, best practices, and actionable next steps. The portfolio highlights how clear communication accelerates adoption and reduces confusion when rolling out new technologies or policies.
+


### PR DESCRIPTION
## Summary
- add README summarizing the portfolio
- add developer docs examples
- add AI and data docs examples
- add enterprise change comms docs
- add strategy and governance docs
- add templates and toolkits
- add CI/CD example for PDF conversion

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686b55c343f88322bea0f410908bb76e